### PR TITLE
Feature/juan/caching

### DIFF
--- a/lighthergm/.Rbuildignore
+++ b/lighthergm/.Rbuildignore
@@ -2,3 +2,4 @@
 ^\.Rproj\.user$
 ^doc$
 ^LICENSE\.md$
+^Meta$

--- a/lighthergm/.gitignore
+++ b/lighthergm/.gitignore
@@ -1,2 +1,4 @@
 .Rproj.user
 inst/doc
+/doc/
+/Meta/

--- a/lighthergm/DESCRIPTION
+++ b/lighthergm/DESCRIPTION
@@ -37,7 +37,9 @@ Imports:
     reticulate,
     tidyr,
     statnet.common,
-    doParallel
+    doParallel,
+    memoise,
+    cachem
 Suggests: 
     rmarkdown,
     knitr,

--- a/lighthergm/R/EM_wrapper.R
+++ b/lighthergm/R/EM_wrapper.R
@@ -22,6 +22,8 @@ EM_wrapper <-
     n_nodes <- as.integer(network$gal$n)
     is_undirected <- !network$gal$directed
 
+    eigenvectors_sparse_cached <- memoise::memoise(eigenvectors_sparse)
+
     # If restart_object is NULL, initialize memberships.
     if (is.null(EM_restart_object)) {
       # Step 0: Initialization
@@ -41,7 +43,7 @@ EM_wrapper <-
       # If you already have an initialized clustering result, start the EM iterations from the given clustering result.
       if (!is.null(initialized_cluster_data)) {
         z_memb_init <- factor(initialized_cluster_data, levels = 1:n_clusters)
-        z_memb <- check_clusters_sparse(z_memb_init, g, n_clusters, min_size, verbose = verbose)
+        z_memb <- check_clusters_sparse(z_memb_init, g, n_clusters, eigenvectors_sparse_cached, min_size, verbose = verbose)
       }
 
       # Start cluster initialization
@@ -67,7 +69,7 @@ EM_wrapper <-
             b <- readr::read_delim(temp_clu[1], delim = " ", skip = 9, col_names = c("node_id", "block", "flow"), col_types = "iid")
             b <- as.numeric(dplyr::arrange(b, by_group = node_id)$block)
             z_memb_init <- factor(b, levels = 1:n_clusters)
-            z_memb <- check_clusters_sparse(z_memb_init, g, n_clusters, min_size, verbose = verbose)
+            z_memb <- check_clusters_sparse(z_memb_init, g, n_clusters, eigenvectors_sparse_cached, min_size, verbose = verbose)
             # Remove tempfiles just in case
             invisible(file.remove(temp))
             invisible(file.remove(temp_clu))
@@ -77,7 +79,7 @@ EM_wrapper <-
             set.seed(seed_infomap)
             b <- igraph::cluster_infomap(intergraph::asIgraph(network))
             z_memb_init <- factor(b$membership, levels = 1:n_clusters)
-            z_memb <- check_clusters_sparse(z_memb_init, g, n_clusters, min_size, verbose = verbose)
+            z_memb <- check_clusters_sparse(z_memb_init, g, n_clusters, eigenvectors_sparse_cached, min_size, verbose = verbose)
           }
         }
       else if (initialization_method == 2) {
@@ -86,7 +88,7 @@ EM_wrapper <-
       }
       else # Spectral clustering
       {
-        z_memb <- spec_clust_sparse(g, n_clusters)
+        z_memb <- spec_clust_sparse(g, n_clusters, eigenvectors_sparse_cached)
         z_memb_init <- z_memb
       }
 
@@ -349,7 +351,7 @@ EM_wrapper <-
 
     # Check bad clusters
     z_memb_final <-
-      factor(check_clusters_sparse(z_memb, g, n_clusters, min_size, verbose = verbose),
+      factor(check_clusters_sparse(z_memb, g, n_clusters, eigenvectors_sparse_cached, min_size, verbose = verbose),
         levels = 1:n_clusters
       )
 
@@ -442,11 +444,11 @@ permute_tau <- function(tau, labels) {
 #' function for spectral clustering
 #' @param network a sparse adjacency matrix
 #' @param n_clusters number of specified clusters
-spec_clust_sparse <- function(network, n_clusters) {
+spec_clust_sparse <- function(network, n_clusters, eigenvectors_fn) {
   n <- nrow(network)
   n_vec <- ceiling(sqrt(n))
   message("Calculating eigenvectors...")
-  b <- eigenvectors_sparse(network, n_vec)
+  b <- eigenvectors_fn(network, n_vec)
   message("K-means clustering...")
   c <- kmeans(
     b,
@@ -462,7 +464,7 @@ spec_clust_sparse <- function(network, n_clusters) {
 
 
 check_clusters_sparse <-
-  function(z_memb, network, n_clusters, min_size = 2, verbose = verbose) {
+  function(z_memb, network, n_clusters, eigenvectors_fn, min_size = 2, verbose = verbose) {
     n <- nrow(network)
     n_vec <- ceiling(sqrt(n))
 
@@ -470,7 +472,7 @@ check_clusters_sparse <-
       message("Eigenvalue decomposition")
     }
 
-    b <- eigenvectors_sparse(network, n_vec)
+    b <- eigenvectors_fn(network, n_vec)
     z_memb <- factor(z_memb, levels = 1:n_clusters)
 
     if (verbose > 0) {

--- a/lighthergm/R/EM_wrapper.R
+++ b/lighthergm/R/EM_wrapper.R
@@ -18,11 +18,17 @@ EM_wrapper <-
            check_block_membership = FALSE,
            EM_restart_object = NULL,
            minAlpha = 1e-6,
+           cache,
            ...) {
     n_nodes <- as.integer(network$gal$n)
     is_undirected <- !network$gal$directed
 
-    eigenvectors_sparse_cached <- memoise::memoise(eigenvectors_sparse)
+    # Cache eigenvectors computation in disk to free memory for other computations
+    if(is.null(cache)){
+      eigenvectors_sparse_fn <- eigenvectors_sparse
+    } else {
+      eigenvectors_sparse_fn <- memoise::memoise(eigenvectors_sparse, cache = cache)
+    }
 
     # If restart_object is NULL, initialize memberships.
     if (is.null(EM_restart_object)) {
@@ -43,7 +49,7 @@ EM_wrapper <-
       # If you already have an initialized clustering result, start the EM iterations from the given clustering result.
       if (!is.null(initialized_cluster_data)) {
         z_memb_init <- factor(initialized_cluster_data, levels = 1:n_clusters)
-        z_memb <- check_clusters_sparse(z_memb_init, g, n_clusters, eigenvectors_sparse_cached, min_size, verbose = verbose)
+        z_memb <- check_clusters_sparse(z_memb_init, g, n_clusters, eigenvectors_sparse_fn, min_size, verbose = verbose)
       }
 
       # Start cluster initialization
@@ -69,7 +75,7 @@ EM_wrapper <-
             b <- readr::read_delim(temp_clu[1], delim = " ", skip = 9, col_names = c("node_id", "block", "flow"), col_types = "iid")
             b <- as.numeric(dplyr::arrange(b, by_group = node_id)$block)
             z_memb_init <- factor(b, levels = 1:n_clusters)
-            z_memb <- check_clusters_sparse(z_memb_init, g, n_clusters, eigenvectors_sparse_cached, min_size, verbose = verbose)
+            z_memb <- check_clusters_sparse(z_memb_init, g, n_clusters, eigenvectors_sparse_fn, min_size, verbose = verbose)
             # Remove tempfiles just in case
             invisible(file.remove(temp))
             invisible(file.remove(temp_clu))
@@ -79,7 +85,7 @@ EM_wrapper <-
             set.seed(seed_infomap)
             b <- igraph::cluster_infomap(intergraph::asIgraph(network))
             z_memb_init <- factor(b$membership, levels = 1:n_clusters)
-            z_memb <- check_clusters_sparse(z_memb_init, g, n_clusters, eigenvectors_sparse_cached, min_size, verbose = verbose)
+            z_memb <- check_clusters_sparse(z_memb_init, g, n_clusters, eigenvectors_sparse_fn, min_size, verbose = verbose)
           }
         }
       else if (initialization_method == 2) {
@@ -88,7 +94,7 @@ EM_wrapper <-
       }
       else # Spectral clustering
       {
-        z_memb <- spec_clust_sparse(g, n_clusters, eigenvectors_sparse_cached)
+        z_memb <- spec_clust_sparse(g, n_clusters, eigenvectors_sparse_fn)
         z_memb_init <- z_memb
       }
 
@@ -351,7 +357,7 @@ EM_wrapper <-
 
     # Check bad clusters
     z_memb_final <-
-      factor(check_clusters_sparse(z_memb, g, n_clusters, eigenvectors_sparse_cached, min_size, verbose = verbose),
+      factor(check_clusters_sparse(z_memb, g, n_clusters, eigenvectors_sparse_fn, min_size, verbose = verbose),
         levels = 1:n_clusters
       )
 
@@ -444,6 +450,7 @@ permute_tau <- function(tau, labels) {
 #' function for spectral clustering
 #' @param network a sparse adjacency matrix
 #' @param n_clusters number of specified clusters
+#' @param eigenvectors_fn a function that performs eigenvector decomposition
 spec_clust_sparse <- function(network, n_clusters, eigenvectors_fn) {
   n <- nrow(network)
   n_vec <- ceiling(sqrt(n))

--- a/lighthergm/R/hergm.R
+++ b/lighthergm/R/hergm.R
@@ -40,6 +40,7 @@
 #' @param check_alpha_update If `TRUE`, this function keeps track of alpha matrices at each EM iteration.
 #' If the network is large, we strongly recommend to set to be `FALSE`.
 #' @param check_block_membership If TRUE, this function keeps track of estimated block memberships at each EM iteration.
+#' @param cache a `cachem` cache object used to store intermediate calculations such as eigenvector decomposition results.
 #' @param ... Additional arguments, to be passed to lower-level functions
 #'
 #' @examples
@@ -80,6 +81,7 @@ hergm <- function(object,
                   compute_pi = FALSE,
                   check_alpha_update = FALSE,
                   check_block_membership = FALSE,
+                  cache = NULL,
                   ...) {
   ###################################################################################
   ###### Preparations for estimation ################################################
@@ -232,7 +234,8 @@ hergm <- function(object,
       compute_pi = compute_pi,
       check_alpha_update = check_alpha_update,
       check_block_membership = check_block_membership,
-      EM_restart_object = EM_restart_object
+      EM_restart_object = EM_restart_object,
+      cache = cache
     )
 
     block_membership <- answer$z_memb_final

--- a/lighthergm/man/hergm.Rd
+++ b/lighthergm/man/hergm.Rd
@@ -25,6 +25,7 @@ hergm(
   compute_pi = FALSE,
   check_alpha_update = FALSE,
   check_block_membership = FALSE,
+  cache = NULL,
   ...
 )
 }
@@ -85,6 +86,8 @@ If the network is large, we strongly recommend to set to be \code{FALSE}.}
 If the network is large, we strongly recommend to set to be \code{FALSE}.}
 
 \item{check_block_membership}{If TRUE, this function keeps track of estimated block memberships at each EM iteration.}
+
+\item{cache}{a \code{cachem} cache object used to store intermediate calculations such as eigenvector decomposition results.}
 
 \item{...}{Additional arguments, to be passed to lower-level functions}
 }

--- a/lighthergm/man/spec_clust_sparse.Rd
+++ b/lighthergm/man/spec_clust_sparse.Rd
@@ -4,12 +4,14 @@
 \alias{spec_clust_sparse}
 \title{function for spectral clustering}
 \usage{
-spec_clust_sparse(network, n_clusters)
+spec_clust_sparse(network, n_clusters, eigenvectors_fn)
 }
 \arguments{
 \item{network}{a sparse adjacency matrix}
 
 \item{n_clusters}{number of specified clusters}
+
+\item{eigenvectors_fn}{a function that performs eigenvector decomposition}
 }
 \description{
 function for spectral clustering

--- a/lighthergm/tests/testthat/test-cache.R
+++ b/lighthergm/tests/testthat/test-cache.R
@@ -1,0 +1,105 @@
+set.seed(334)
+
+# Simulate a random network for testing
+simulate_network <- function(){
+  N <- 1000
+  K <- 50
+  memb <- rep(1:K, each = N / K)
+  x <- sample(1:10, size = N, replace = TRUE)
+  y <- sample(1:10, size = N, replace = TRUE)
+  list_within_params <- c(-1, 1, 1, 0.5)
+  list_between_params <- c(-3.5, 0.5, 0.5)
+
+  formula <- g ~ edges + nodematch("x") + nodematch("y") + triangle
+
+  vertex_id <- 1:N
+
+  df <- tibble::tibble(
+    id = vertex_id,
+    memb = memb,
+    x = x,
+    y = y
+  )
+
+  simulate_hergm(
+      formula_for_simulation = formula,
+      data_for_simulation = df,
+      colname_vertex_id = "id",
+      colname_block_membership = "memb",
+      coef_within_block = list_within_params,
+      coef_between_block = list_between_params,
+      ergm_control = ergm::control.simulate.formula(MCMC.burnin = 1000000, MCMC.interval = 1000),
+      seed = 1,
+      n_sim = 1,
+      directed = FALSE,
+      output = "network"
+    )
+}
+
+# Function that checks that the number of files in the directory is the expected number
+check_files <- function(dir, expected_number){
+  expect_equal(length(list.files(dir, '*.rds')), expected_number)
+}
+
+cleanup <- function(){
+  do.call(file.remove, list(list.files(tempdir(), '*.rds', full.names = TRUE)))
+}
+
+test_that('Estimation with a disk cache stores data in the correct directory', {
+  on.exit(cleanup())
+
+  # Use this directory for caching in disk
+  dir <- tempdir()
+
+  # Simulate a network
+  g_1 <- simulate_network()
+
+  # There should be no cached files in the directory
+  check_files(dir, 0)
+
+  # Perform estimation
+  lighthergm::hergm(
+    object = g_1 ~ edges + nodematch("x"),
+    n_clusters = 20,
+    n_em_step_max = 3,
+    initialization_method = 1,
+    clustering_with_features = TRUE,
+    verbose=2,
+    cache = cachem::cache_disk(dir)
+  )
+
+  # The estimation should have stored one RDS object in the cache directory.
+  check_files(dir, 1)
+
+  lighthergm::hergm(
+    object = g_1 ~ edges + nodematch("x"),
+    n_clusters = 20,
+    n_em_step_max = 3,
+    initialization_method = 1,
+    clustering_with_features = TRUE,
+    verbose=2,
+    cache = cachem::cache_disk(dir)
+  )
+
+  # Running again the estimation on the same network should reuse the previously stored RDS object
+  # and not store a new one.
+  check_files(dir, 1)
+
+  # Generate a different network
+  g_2 <- simulate_network()
+
+  # Perform estimation on the new network.
+  lighthergm::hergm(
+    object = g_2 ~ edges + nodematch("x"),
+    n_clusters = 20,
+    n_em_step_max = 3,
+    initialization_method = 1,
+    clustering_with_features = TRUE,
+    verbose=2,
+    cache = cachem::cache_disk(dir)
+  )
+
+  # The network has changed, so the previously cached RDS is not reused and a new cache file is generated.
+  check_files(dir, 2)
+
+})

--- a/lighthergm/vignettes/intro-lighthergm.Rmd
+++ b/lighthergm/vignettes/intro-lighthergm.Rmd
@@ -164,6 +164,8 @@ summary(hergm_res$est_within)
 
 Currently, the only supported way to include covariates in the model is via `nodematch()`.
 
+You can also employ caching to avoid repeating heavy operations that yield the same results for your network. To use it, pass the `cache` parameter to `lighthergm::hergm`, setting its value to a [cachem](https://github.com/r-lib/cachem "cachem repository") object. A disk cache lets you speed up estimations on the same network data even across R Sessions.
+
 # Goodness-of-fit
 
 You can evaluate the goodness-of-fit of the model with the `lighthergm::gof_lighthergm()` function:


### PR DESCRIPTION
Closes #4 

There are a few operations within `lighthergm::hergm` that can be cached, including:
1. Eigenvector decomposition
2. Constructing the feature adjacency matrices

Both operations only depend on the data, and not on the settings of the algorithm, and can be very expensive.
In this PR I introduce the `cache` argument to `lighthergm::hergm`, which allows you to pass a `cachem` object (`cache_disk`, `cache_mem`, etc.), so that the user can choose the caching strategy they prefer (the default uses no cache).
See the unit test included in this PR for a reproducible example.

Currently, the cache is passed to `memoise` and i only used for the `eigenvectors_sparse` function. There are several benefits of using cache:

- To save memory. For example, the `eigenvectors_sparse` function is executed at the beginning of the block recovery step, and once again after the EM algorithm has ended. This function takes a lot of time on large networks, so it doesn't make sense to run it twice with the same arguments. You could just keep the result object from the first run in memory and reuse it on the second run, but that hogs memory. By caching it in disk, you only put it into memory when you need it.
- Being able to use a disk cache means that you can store the cached objects across R sessions, and even put them on remote storage to share with others in your research team.

We already do something similar through the `list_feature_matrices` argument, but the way we do it is very ad-hoc. It would be simpler to treat all cached objects similarly.
