### PR TITLE
Feature/juan/within sim with seed edgelist

### DIFF
--- a/lighthergm/R/simulate_hergm.R
+++ b/lighthergm/R/simulate_hergm.R
@@ -830,7 +830,7 @@ simulate_hergm_within <- function(formula_for_simulation,
   }
 
   seed_network_within <-
-    generate_seed_network(formula_for_simulation, sorted_dataframe, directed = FALSE)
+    generate_seed_network(formula_for_simulation, sorted_dataframe, edgelist = seed_edgelist_within, directed = FALSE)
 
   # Create formula for simulating within-block networks.
   ## Extract the RHS of the given formula

--- a/lighthergm/tests/testthat/test-simulate_hergm.R
+++ b/lighthergm/tests/testthat/test-simulate_hergm.R
@@ -188,7 +188,7 @@ test_that("The simulation begins from an empty network by default", {
       directed = FALSE
     )
 
-  expect_match(class(g2), "network")
+  expect_match(class(g_sim), "network")
 
   g_sim <- network::as.edgelist(g_sim)
 

--- a/lighthergm/tests/testthat/test-simulate_hergm.R
+++ b/lighthergm/tests/testthat/test-simulate_hergm.R
@@ -146,6 +146,56 @@ test_that("simulating a network from a given edgelist works", {
   expect_true(all(g_sim == g2))
 })
 
+test_that("The simulation begins from an empty network by default", {
+  set.seed(1)
+  # Prepare ingredients for simulating a network
+  N <- 1000
+  K <- 10
+
+  list_within_params <- c(-3, 1, 1, 0.76, 0.08)
+  list_between_params <- c(-5, 2, 2)
+  formula <- g ~ edges + nodematch("x") + nodematch("y") + triangle + kstar(2)
+
+  memb <- sample(1:K, size = N, replace = TRUE)
+  vertex_id <- as.character(11:(11 + N - 1))
+
+  x <- sample(1:20, size = N, replace = TRUE)
+  y <- sample(LETTERS, size = N, replace = TRUE)
+
+  df <- tibble::tibble(
+    id = vertex_id,
+    memb = memb,
+    x = x,
+    y = y
+  )
+
+  # Simulate a network
+  g_sim <-
+    simulate_hergm(
+      formula_for_simulation = formula,
+      data_for_simulation = df,
+      colname_vertex_id = "id",
+      colname_block_membership = "memb",
+      coef_within_block = list_within_params,
+      coef_between_block = list_between_params,
+      ergm_control = ergm::control.simulate.formula(
+        MCMC.burnin = 0,
+        MCMC.interval = 1
+      ),
+      seed_for_within = 1,
+      seed_for_between = 1,
+      n_sim = 1,
+      directed = FALSE
+    )
+
+  expect_match(class(g2), "network")
+
+  g_sim <- network::as.edgelist(g_sim)
+
+  # Check if the network is correctly generated
+  expect_equal(nrow(g_sim), 0)
+})
+
 test_that("generating multiple networks works", {
   set.seed(1)
   # Prepare ingredients for simulating a network

--- a/lighthergm/tests/testthat/test-simulate_hergm.R
+++ b/lighthergm/tests/testthat/test-simulate_hergm.R
@@ -87,7 +87,6 @@ test_that("simulating a network from a given edgelist works", {
   x <- sample(1:20, size = N, replace = TRUE)
   y <- sample(LETTERS, size = N, replace = TRUE)
 
-
   df <- tibble::tibble(
     id = vertex_id,
     memb = memb,
@@ -104,14 +103,16 @@ test_that("simulating a network from a given edgelist works", {
       colname_block_membership = "memb",
       coef_within_block = list_within_params,
       coef_between_block = list_between_params,
-      ergm_control = ergm::control.simulate.formula(),
+      ergm_control = ergm::control.simulate.formula(
+        MCMC.burnin = 10000,
+        MCMC.interval = 100
+      ),
       seed_for_within = 1,
       seed_for_between = 1,
       n_sim = 1,
       directed = FALSE
     )
 
-  # Convert to an edgelist
   g_sim <- network::as.edgelist(g_sim)
 
   # Simulate a network from a given edgelist
@@ -123,7 +124,12 @@ test_that("simulating a network from a given edgelist works", {
       colname_block_membership = "memb",
       coef_within_block = list_within_params,
       coef_between_block = list_between_params,
-      ergm_control = ergm::control.simulate.formula(),
+      # These settings should result on the exact same network being returned
+      # after one simulation. Check that.
+      ergm_control = ergm::control.simulate.formula(
+        MCMC.burnin = 0,
+        MCMC.interval = 1
+      ),
       seed_for_within = 1,
       seed_for_between = 1,
       seed_edgelist = g_sim,
@@ -131,8 +137,13 @@ test_that("simulating a network from a given edgelist works", {
       directed = FALSE
     )
 
-  # Check if the network is correctly generated
   expect_match(class(g2), "network")
+
+  g2 <- network::as.edgelist(g2)
+
+  # Check if the network is correctly generated
+  expect_equal(nrow(g_sim), nrow(g2))
+  expect_true(all(g_sim == g2))
 })
 
 test_that("generating multiple networks works", {

--- a/lighthergm/tests/testthat/test-within-network-stats.R
+++ b/lighthergm/tests/testthat/test-within-network-stats.R
@@ -40,3 +40,80 @@ test_that("generating multiple networks works", {
   expect_equal(length(expected_terms), length(names(within_sim_stats)))
 
 })
+
+test_that("simulating a network from a given edgelist works", {
+  set.seed(1)
+  # Prepare ingredients for simulating a network
+  N <- 1000
+  K <- 10
+
+  list_within_params <- c(-3, 1, 1, 0.76, 0.08)
+  list_between_params <- c(-5, 2, 2)
+  formula <- g ~ edges + nodematch("x") + nodematch("y") + triangle + kstar(2)
+
+  memb <- sample(1:K, size = N, replace = TRUE)
+  vertex_id <- as.character(11:(11 + N - 1))
+
+  x <- sample(1:20, size = N, replace = TRUE)
+  y <- sample(LETTERS, size = N, replace = TRUE)
+
+  df <- tibble::tibble(
+    id = vertex_id,
+    memb = memb,
+    x = x,
+    y = y
+  )
+
+  # Simulate a network
+  g_sim <-
+    simulate_hergm_within(
+      formula_for_simulation = formula,
+      data_for_simulation = df,
+      colname_vertex_id = "id",
+      colname_block_membership = "memb",
+      coef_within_block = list_within_params,
+      coef_between_block = list_between_params,
+      ergm_control = ergm::control.simulate.formula(
+        MCMC.burnin = 10000,
+        MCMC.interval = 100
+      ),
+      seed_for_within = 1,
+      seed_for_between = 1,
+      n_sim = 1,
+      directed = FALSE,
+      output = 'network'
+    )
+
+  g_sim <- network::as.edgelist(g_sim)
+
+  # Simulate a network from a given edgelist
+  g2 <-
+    simulate_hergm_within(
+      formula_for_simulation = formula,
+      data_for_simulation = df,
+      colname_vertex_id = "id",
+      colname_block_membership = "memb",
+      coef_within_block = list_within_params,
+      coef_between_block = list_between_params,
+      # These settings should result on the exact same network being returned
+      # after one simulation. Check that.
+      ergm_control = ergm::control.simulate.formula(
+        MCMC.burnin = 0,
+        MCMC.interval = 1
+      ),
+      seed_for_within = 1,
+      seed_for_between = 1,
+      seed_edgelist = g_sim,
+      n_sim = 1,
+      directed = FALSE,
+      output = 'network'
+    )
+
+  expect_match(class(g2), "network")
+
+  g2 <- network::as.edgelist(g2)
+
+  # Check if the network is correctly generated
+  expect_equal(nrow(g_sim), nrow(g2))
+  expect_true(all(g_sim == g2))
+})

--- a/lighthergm/tests/testthat/test-within-network-stats.R
+++ b/lighthergm/tests/testthat/test-within-network-stats.R
@@ -118,7 +118,7 @@ test_that("simulating a network from a given edgelist works", {
   expect_true(all(g_sim == g2))
 })
 
-test_that("simulating a network from a given edgelist works", {
+test_that("The within-simulation begins from an empty network by default", {
   set.seed(1)
   # Prepare ingredients for simulating a network
   N <- 1000
@@ -166,5 +166,4 @@ test_that("simulating a network from a given edgelist works", {
 
   # Check if the network is correctly generated
   expect_equal(nrow(g_sim), 0)
-  expect_true(all(g_sim == g2))
 })


### PR DESCRIPTION
Closes #18 

The within-block simulation function was not passing the seed edgelist to `generate_seed_network`.
`simulate_hergm_within` is used for within-block goodness-of-fit assessment, so bad within-block gof results in previous versions may be attributed to this.