### PR TITLE
Start GOF from observed network

### DIFF
--- a/lighthergm/R/gof_lighthergm.R
+++ b/lighthergm/R/gof_lighthergm.R
@@ -158,8 +158,8 @@ gof_lighthergm <- function(net,
                            n_sim = 1,
                            prevent_duplicate = TRUE,
                            compute_geodesic_distance = FALSE,
+                           start_from_observed = FALSE,
                            ...) {
-
   # Setup
   gof_formula <- swap_formula_network(net, lighthergm_results$est_within$formula, environment())
   burnin <- ergm_control$MCMC.burnin
@@ -173,14 +173,25 @@ gof_lighthergm <- function(net,
     stop("The `type` argument must be any of 'full' or 'within'")
   }
 
+  seed_edgelist = NULL
+
   if (type == 'full'){
     original_stats <- get_gof_stats(gof_formula, compute_geodesic_distance = compute_geodesic_distance)
+
+    if(start_from_observed){
+      seed_edgelist <- network::as.edgelist(net)
+    }
+
   } else {
     sorted_dataframe <- sort_block_membership(data_for_simulation, colname_vertex_id, colname_block_membership)
     seed_edgelist_within <- arrange_edgelist(network::as.edgelist(net), sorted_dataframe)$edgelist_within
     within_network <- generate_seed_network(gof_formula, sorted_dataframe, edgelist = seed_edgelist_within, directed = FALSE)
 
     original_stats <- get_gof_stats(gof_formula, net = within_network, compute_geodesic_distance = compute_geodesic_distance)
+
+    if(start_from_observed){
+      seed_edgelist <- network::as.edgelist(within_network)
+    }
   }
 
   # Simulate the first network by initializing it from zero. The burnin here is the one set by the user.
@@ -190,6 +201,7 @@ gof_lighthergm <- function(net,
       data_for_simulation = data_for_simulation,
       colname_vertex_id = colname_vertex_id,
       colname_block_membership = colname_block_membership,
+      seed_edgelist = seed_edgelist,
       coef_within_block = coef_within_block,
       coef_between_block = coef_between_block,
       ergm_control = ergm_control,
@@ -208,6 +220,7 @@ gof_lighthergm <- function(net,
       data_for_simulation = data_for_simulation,
       colname_vertex_id = colname_vertex_id,
       colname_block_membership = colname_block_membership,
+      seed_edgelist = seed_edgelist,
       coef_within_block = coef_within_block,
       output = 'network',
       ergm_control = ergm_control,

--- a/lighthergm/R/gof_lighthergm.R
+++ b/lighthergm/R/gof_lighthergm.R
@@ -163,7 +163,6 @@ gof_lighthergm <- function(net,
                            ...) {
   # Setup
   gof_formula <- swap_formula_network(net, lighthergm_results$est_within$formula, environment())
-  interval <- ergm_control$MCMC.interval
   coef_within_block <- coef(lighthergm_results$est_within)
   coef_between_block <- coef(lighthergm_results$est_between)
 
@@ -250,8 +249,7 @@ gof_lighthergm <- function(net,
 
   if (effective_nsim > 0) {
     # Now replace the burnin with the interval and simulate networks one by one.
-    ergm_control_sim <- ergm_control
-    ergm_control_sim$MCMC.burnin <- interval
+    ergm_control$MCMC.burnin <- ergm_control$MCMC.interval
 
     for (i in 1:effective_nsim) {
       if ((i + 1) %% 50 == 0) {
@@ -262,18 +260,18 @@ gof_lighthergm <- function(net,
         base_network <- simulate_hergm(
           formula_for_simulation = gof_formula,
           list_feature_matrices = list_feature_matrices,
-          data_for_simulation,
-          colname_vertex_id,
-          colname_block_membership,
+          data_for_simulation = data_for_simulation,
+          colname_vertex_id = colname_vertex_id,
+          colname_block_membership = colname_block_membership,
           seed_edgelist = network::as.edgelist(base_network),
-          coef_within_block,
-          coef_between_block,
-          ergm_control_sim,
-          seed,
+          coef_within_block = coef_within_block,
+          coef_between_block = coef_between_block,
+          ergm_control = ergm_control,
+          seed = seed,
           directed = FALSE,
           n_sim = 1,
           output = "network",
-          prevent_duplicate,
+          prevent_duplicate = prevent_duplicate,
           use_fast_between_simulation = TRUE,
           ...
         )
@@ -286,7 +284,7 @@ gof_lighthergm <- function(net,
           seed_edgelist = network::as.edgelist(base_network),
           coef_within_block = coef_within_block,
           output = 'network',
-          ergm_control = ergm_control_sim,
+          ergm_control = ergm_control,
           seed = seed,
           n_sim = 1
         )

--- a/lighthergm/R/gof_lighthergm.R
+++ b/lighthergm/R/gof_lighthergm.R
@@ -163,7 +163,6 @@ gof_lighthergm <- function(net,
                            ...) {
   # Setup
   gof_formula <- swap_formula_network(net, lighthergm_results$est_within$formula, environment())
-  burnin <- ergm_control$MCMC.burnin
   interval <- ergm_control$MCMC.interval
   coef_within_block <- coef(lighthergm_results$est_within)
   coef_between_block <- coef(lighthergm_results$est_between)

--- a/lighthergm/R/gof_lighthergm.R
+++ b/lighthergm/R/gof_lighthergm.R
@@ -143,6 +143,7 @@ get_gof_stats <- function(sim_formula, net = NULL, sim_number = NULL, compute_ge
 #' @param n_sim the number of simulations to employ for calculating goodness of fit
 #' @param prevent_duplicate see `simulate_hergm`
 #' @param compute_geodesic_distance if `TRUE`, the distribution of geodesic distances is also computed (considerably increases computation time on large networks. `FALSE` by default.)
+#' @param start_from_observed if `TRUE`, MCMC uses the observed network as a starting point
 #' @param ... Additional arguments, to be passed to lower-level functions
 #'
 #' @export
@@ -286,7 +287,7 @@ gof_lighthergm <- function(net,
           seed_edgelist = network::as.edgelist(base_network),
           coef_within_block = coef_within_block,
           output = 'network',
-          ergm_control = ergm_control,
+          ergm_control = ergm_control_sim,
           seed = seed,
           n_sim = 1
         )

--- a/lighthergm/man/gof_lighthergm.Rd
+++ b/lighthergm/man/gof_lighthergm.Rd
@@ -17,6 +17,7 @@ gof_lighthergm(
   n_sim = 1,
   prevent_duplicate = TRUE,
   compute_geodesic_distance = FALSE,
+  start_from_observed = FALSE,
   ...
 )
 }

--- a/lighthergm/man/gof_lighthergm.Rd
+++ b/lighthergm/man/gof_lighthergm.Rd
@@ -46,6 +46,8 @@ gof_lighthergm(
 
 \item{compute_geodesic_distance}{if \code{TRUE}, the distribution of geodesic distances is also computed (considerably increases computation time on large networks. \code{FALSE} by default.)}
 
+\item{start_from_observed}{if \code{TRUE}, MCMC uses the observed network as a starting point}
+
 \item{...}{Additional arguments, to be passed to lower-level functions}
 }
 \description{

--- a/lighthergm/tests/testthat/test-gof.R
+++ b/lighthergm/tests/testthat/test-gof.R
@@ -278,7 +278,7 @@ test_that("Within-connections GOF can be started from the observed network", {
 
   first_simulation_stats <-test_gof_res$simulated$network_stats %>%
     dplyr::filter(n_sim == 1) %>%
-    select(-n_sim)
+    dplyr::select(-n_sim)
 
   original_network_stats <- test_gof_res$original$network_stats
   expect_equal(original_network_stats, first_simulation_stats)

--- a/lighthergm/tests/testthat/test-gof.R
+++ b/lighthergm/tests/testthat/test-gof.R
@@ -253,3 +253,62 @@ test_that("Return GOF statistics including only within-block connections", {
     expect_true(is.null(stats[["geodesic_dist"]]))
   }
 })
+
+test_that("Within-connections GOF can be started from the observed network", {
+  sim <- get_dummy_net(100, 4)
+  g <- sim$g
+
+  ergm_control <- ergm::control.simulate.formula(
+    MCMC.burnin = 0,
+    MCMC.interval = 1
+  )
+
+  test_gof_res <- lighthergm::gof_lighthergm(
+    g,
+    list_feature_matrices = sim$list_feature_matrices,
+    data_for_simulation = sim$nodes_data,
+    colname_vertex_id = sim$vertex_id_var,
+    colname_block_membership = sim$block_id_var,
+    lighthergm_results = sim$hergm_res,
+    type = 'within',
+    ergm_control = ergm_control,
+    n_sim = 2,
+    start_from_observed = TRUE
+  )
+
+  first_simulation_stats <-test_gof_res$simulated$network_stats %>%
+    dplyr::filter(n_sim == 1) %>%
+    select(-n_sim)
+
+  original_network_stats <- test_gof_res$original$network_stats
+  expect_equal(original_network_stats, first_simulation_stats)
+})
+
+test_that("Full GOF can be started from the observed network", {
+  sim <- get_dummy_net(100, 4)
+  g <- sim$g
+
+  ergm_control <- ergm::control.simulate.formula(
+    MCMC.burnin = 0,
+    MCMC.interval = 1
+  )
+
+  test_gof_res <- lighthergm::gof_lighthergm(
+    g,
+    list_feature_matrices = sim$list_feature_matrices,
+    data_for_simulation = sim$nodes_data,
+    colname_vertex_id = sim$vertex_id_var,
+    colname_block_membership = sim$block_id_var,
+    lighthergm_results = sim$hergm_res,
+    type = 'full',
+    ergm_control = ergm_control,
+    n_sim = 2,
+    start_from_observed = TRUE
+  )
+
+  first_simulation_stats <-test_gof_res$simulated$network_stats %>%
+    dplyr::filter(n_sim == 1)
+
+  # If it starts from the observed network, the stats should not be zero
+  expect_true(all(first_simulation_stats['value'] > 0))
+})


### PR DESCRIPTION
This PR makes it possible to start the MCMC simulations for GOF from the observed network, by using the `start_fom_observed` argument.

I added a few additional tests to check that the right seed edgelist is employed.